### PR TITLE
adding get_installed_version_office with installed software module

### DIFF
--- a/tests/test_office.py
+++ b/tests/test_office.py
@@ -19,7 +19,14 @@ __copyright__ = "Copyright (C) 2020-2021 Orsiris de Jong"
 __licence__ = "BSD 3 Clause"
 __build__ = "2021021601"
 
+#using a virtual env to not confuse with windows_tools outside of the project
+import sys
+import os
+#adding temporary module in path while running in virtual env
+sys.path.insert(0, '../windows_tools/')
+print(os.getcwd())
 from windows_tools.office import *
+
 
 
 def test_get_office_version():
@@ -28,7 +35,7 @@ def test_get_office_version():
     Hence we allow None as return value too, rendering the test not very useful
     """
 
-    office_version, click_and_run = get_office_version()
+    office_version, click_and_run,installed_version = get_office_version()
     print("Office version detected: {} {}".format(office_version, click_and_run))
     assert office_version in list(KNOWN_VERSIONS.values()) + [
         "2016",
@@ -38,6 +45,17 @@ def test_get_office_version():
     ], "Bogus office version detected"
 
 
+def test_get_installed_version_office():
+    """
+    using the installed_software module to get the installed version of office
+    """
+    office_version, click_and_run,installed_version = get_office_version()
+    print(installed_version)
+
+
+
 if __name__ == "__main__":
     print("Example code for %s, %s" % (__intname__, __build__))
     test_get_office_version()
+    print("testing with installed software module")
+    test_get_installed_version_office()

--- a/windows_tools/office/__init__.py
+++ b/windows_tools/office/__init__.py
@@ -24,6 +24,7 @@ __build__ = "2021101002"
 from typing import Tuple, Optional
 
 from windows_tools import registry
+from windows_tools.installed_software import get_installed_software
 
 # Let's make sure the dictionary goes from most recent to oldest
 KNOWN_VERSIONS = {
@@ -108,6 +109,18 @@ def _get_installed_office_version():
             pass
     return None, None
 
+def get_installed_version_office():
+    """
+    using the get_installed_software module to get the installed office version 
+    this function returns an empty array if no version is found in the installed 
+    software package
+    """
+    installed_office=[] 
+    for i in get_installed_software():
+        if "microsoft" in i.get("name").lower() and "office" in i.get("name").lower() :
+            installed_office.append(i.get("name"))
+    return installed_office
+
 
 def get_office_version():
     # type: () -> Tuple[str, Optional[str]]
@@ -153,4 +166,6 @@ def get_office_version():
     else:
         click_and_run_suffix = ""
 
-    return _get_office_version(), click_and_run_suffix
+
+
+    return _get_office_version(), click_and_run_suffix , get_installed_version_office()


### PR DESCRIPTION
#### Reference Issues/PRs
None
#### What does this implement/fix? Explain your changes.
the reason for this pull request is to add a better way to get the office version using the installed software package 
what usually needed when developing application with this library is to get the possible office version **installed** I know my code can be fixed and updated more but something like this is a better solution .
example output 
![image](https://user-images.githubusercontent.com/30938650/212665358-b5a934c9-d248-47f6-9d92-ccb874c33239.png)
what is simply happening is that we use the installed software module to get list off software then we filter on any software with the string 'office' and 'Microsoft' **combined** in it.
#### Any other comments?
it's a great project hope to see it grow more.