### PR TITLE
Fix update state assignment by using the correct mapping from states

### DIFF
--- a/windows_tools/updates/__init__.py
+++ b/windows_tools/updates/__init__.py
@@ -163,7 +163,7 @@ def get_windows_updates_reg(
         32: "Resolved",
         48: "Staging",
         64: "Staged",
-        80: "Superseeded",
+        80: "Superseded",
         96: "Install Pending",
         101: "Partially Installed",
         112: "Installed",
@@ -196,7 +196,7 @@ def get_windows_updates_reg(
         except KeyError:
             pass
         try:
-            update["result"] = key["CurrentState"]["value"]
+            update["result"] = states[key["CurrentState"]["value"]]
         except KeyError:
             pass
         try:


### PR DESCRIPTION
When parsing the data from `reg` the result is set as the int value instead of the string like it is done when pared from `com`